### PR TITLE
Request to run 2016-01 and extra review for the new year.

### DIFF
--- a/Buildconf/cplconf/atm_modelio.nml_0001
+++ b/Buildconf/cplconf/atm_modelio.nml_0001
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/atm"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "atm_0001.log.200419-115715"
+  logfile = "atm_0001.log.200421-164803"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/Buildconf/cplconf/atm_modelio.nml_0002
+++ b/Buildconf/cplconf/atm_modelio.nml_0002
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/atm"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "atm_0002.log.200419-115715"
+  logfile = "atm_0002.log.200421-164803"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/Buildconf/cplconf/cpl_modelio.nml_0001
+++ b/Buildconf/cplconf/cpl_modelio.nml_0001
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/cpl"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "cpl_0001.log.200419-115715"
+  logfile = "cpl_0001.log.200421-164803"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/Buildconf/cplconf/cpl_modelio.nml_0002
+++ b/Buildconf/cplconf/cpl_modelio.nml_0002
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/cpl"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "cpl_0002.log.200419-115715"
+  logfile = "cpl_0002.log.200421-164803"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/Buildconf/cplconf/esp_modelio.nml_0001
+++ b/Buildconf/cplconf/esp_modelio.nml_0001
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/esp"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "esp_0001.log.200419-115715"
+  logfile = "esp_0001.log.200421-164803"
 /
 &pio_inparm
   pio_netcdf_format = ""

--- a/Buildconf/cplconf/esp_modelio.nml_0002
+++ b/Buildconf/cplconf/esp_modelio.nml_0002
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/esp"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "esp_0002.log.200419-115715"
+  logfile = "esp_0002.log.200421-164803"
 /
 &pio_inparm
   pio_netcdf_format = ""

--- a/Buildconf/cplconf/glc_modelio.nml_0001
+++ b/Buildconf/cplconf/glc_modelio.nml_0001
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/glc"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "glc_0001.log.200419-115715"
+  logfile = "glc_0001.log.200421-164803"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/Buildconf/cplconf/glc_modelio.nml_0002
+++ b/Buildconf/cplconf/glc_modelio.nml_0002
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/glc"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "glc_0002.log.200419-115715"
+  logfile = "glc_0002.log.200421-164803"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/Buildconf/cplconf/ice_modelio.nml_0001
+++ b/Buildconf/cplconf/ice_modelio.nml_0001
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/ice"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "ice_0001.log.200419-115715"
+  logfile = "ice_0001.log.200421-164803"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/Buildconf/cplconf/ice_modelio.nml_0002
+++ b/Buildconf/cplconf/ice_modelio.nml_0002
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/ice"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "ice_0002.log.200419-115715"
+  logfile = "ice_0002.log.200421-164803"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/Buildconf/cplconf/lnd_modelio.nml_0001
+++ b/Buildconf/cplconf/lnd_modelio.nml_0001
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/lnd"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "lnd_0001.log.200419-115715"
+  logfile = "lnd_0001.log.200421-164803"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/Buildconf/cplconf/lnd_modelio.nml_0002
+++ b/Buildconf/cplconf/lnd_modelio.nml_0002
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/lnd"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "lnd_0002.log.200419-115715"
+  logfile = "lnd_0002.log.200421-164803"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/Buildconf/cplconf/ocn_modelio.nml_0001
+++ b/Buildconf/cplconf/ocn_modelio.nml_0001
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/ocn"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "ocn_0001.log.200419-115715"
+  logfile = "ocn_0001.log.200421-164803"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/Buildconf/cplconf/ocn_modelio.nml_0002
+++ b/Buildconf/cplconf/ocn_modelio.nml_0002
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/ocn"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "ocn_0002.log.200419-115715"
+  logfile = "ocn_0002.log.200421-164803"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/Buildconf/cplconf/rof_modelio.nml_0001
+++ b/Buildconf/cplconf/rof_modelio.nml_0001
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/rof"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "rof_0001.log.200419-115715"
+  logfile = "rof_0001.log.200421-164803"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/Buildconf/cplconf/rof_modelio.nml_0002
+++ b/Buildconf/cplconf/rof_modelio.nml_0002
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/rof"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "rof_0002.log.200419-115715"
+  logfile = "rof_0002.log.200421-164803"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/Buildconf/cplconf/wav_modelio.nml_0001
+++ b/Buildconf/cplconf/wav_modelio.nml_0001
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/wav"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "wav_0001.log.200419-115715"
+  logfile = "wav_0001.log.200421-164803"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/Buildconf/cplconf/wav_modelio.nml_0002
+++ b/Buildconf/cplconf/wav_modelio.nml_0002
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/wav"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "wav_0002.log.200419-115715"
+  logfile = "wav_0002.log.200421-164803"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/CaseDocs/atm_modelio.nml_0001
+++ b/CaseDocs/atm_modelio.nml_0001
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/atm"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "atm_0001.log.200419-115715"
+  logfile = "atm_0001.log.200421-164803"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/CaseDocs/atm_modelio.nml_0002
+++ b/CaseDocs/atm_modelio.nml_0002
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/atm"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "atm_0002.log.200419-115715"
+  logfile = "atm_0002.log.200421-164803"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/CaseDocs/cpl_modelio.nml_0001
+++ b/CaseDocs/cpl_modelio.nml_0001
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/cpl"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "cpl_0001.log.200419-115715"
+  logfile = "cpl_0001.log.200421-164803"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/CaseDocs/cpl_modelio.nml_0002
+++ b/CaseDocs/cpl_modelio.nml_0002
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/cpl"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "cpl_0002.log.200419-115715"
+  logfile = "cpl_0002.log.200421-164803"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/CaseDocs/esp_modelio.nml_0001
+++ b/CaseDocs/esp_modelio.nml_0001
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/esp"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "esp_0001.log.200419-115715"
+  logfile = "esp_0001.log.200421-164803"
 /
 &pio_inparm
   pio_netcdf_format = ""

--- a/CaseDocs/esp_modelio.nml_0002
+++ b/CaseDocs/esp_modelio.nml_0002
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/esp"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "esp_0002.log.200419-115715"
+  logfile = "esp_0002.log.200421-164803"
 /
 &pio_inparm
   pio_netcdf_format = ""

--- a/CaseDocs/glc_modelio.nml_0001
+++ b/CaseDocs/glc_modelio.nml_0001
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/glc"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "glc_0001.log.200419-115715"
+  logfile = "glc_0001.log.200421-164803"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/CaseDocs/glc_modelio.nml_0002
+++ b/CaseDocs/glc_modelio.nml_0002
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/glc"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "glc_0002.log.200419-115715"
+  logfile = "glc_0002.log.200421-164803"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/CaseDocs/ice_modelio.nml_0001
+++ b/CaseDocs/ice_modelio.nml_0001
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/ice"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "ice_0001.log.200419-115715"
+  logfile = "ice_0001.log.200421-164803"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/CaseDocs/ice_modelio.nml_0002
+++ b/CaseDocs/ice_modelio.nml_0002
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/ice"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "ice_0002.log.200419-115715"
+  logfile = "ice_0002.log.200421-164803"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/CaseDocs/lnd_modelio.nml_0001
+++ b/CaseDocs/lnd_modelio.nml_0001
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/lnd"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "lnd_0001.log.200419-115715"
+  logfile = "lnd_0001.log.200421-164803"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/CaseDocs/lnd_modelio.nml_0002
+++ b/CaseDocs/lnd_modelio.nml_0002
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/lnd"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "lnd_0002.log.200419-115715"
+  logfile = "lnd_0002.log.200421-164803"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/CaseDocs/ocn_modelio.nml_0001
+++ b/CaseDocs/ocn_modelio.nml_0001
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/ocn"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "ocn_0001.log.200419-115715"
+  logfile = "ocn_0001.log.200421-164803"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/CaseDocs/ocn_modelio.nml_0002
+++ b/CaseDocs/ocn_modelio.nml_0002
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/ocn"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "ocn_0002.log.200419-115715"
+  logfile = "ocn_0002.log.200421-164803"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/CaseDocs/rof_modelio.nml_0001
+++ b/CaseDocs/rof_modelio.nml_0001
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/rof"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "rof_0001.log.200419-115715"
+  logfile = "rof_0001.log.200421-164803"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/CaseDocs/rof_modelio.nml_0002
+++ b/CaseDocs/rof_modelio.nml_0002
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/rof"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "rof_0002.log.200419-115715"
+  logfile = "rof_0002.log.200421-164803"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/CaseDocs/wav_modelio.nml_0001
+++ b/CaseDocs/wav_modelio.nml_0001
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/wav"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "wav_0001.log.200419-115715"
+  logfile = "wav_0001.log.200421-164803"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/CaseDocs/wav_modelio.nml_0002
+++ b/CaseDocs/wav_modelio.nml_0002
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/wav"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "wav_0002.log.200419-115715"
+  logfile = "wav_0002.log.200421-164803"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/env_run.xml
+++ b/env_run.xml
@@ -252,7 +252,7 @@
       timing tests.
     </desc>
     </entry>
-    <entry id="JOB_IDS" value="case.run:1828439.chadmin1.ib0.cheyenne.ucar.edu, case.st_archive:1828440.chadmin1.ib0.cheyenne.ucar.edu">
+    <entry id="JOB_IDS" value="case.run:1849088.chadmin1.ib0.cheyenne.ucar.edu, case.st_archive:1849089.chadmin1.ib0.cheyenne.ucar.edu">
       <type>char</type>
       <desc>List of job ids for most recent case.submit</desc>
     </entry>

--- a/repack_project.csh
+++ b/repack_project.csh
@@ -41,8 +41,8 @@
 #SBATCH --job-name=repack_project
 # Output standard output and error to a file named with 
 # the job-name and the jobid.
-#SBATCH -o %x_%j_2014.eo 
-#SBATCH -e %x_%j_2014.eo 
+#SBATCH -o %x_%j_2015.eo 
+#SBATCH -e %x_%j_2015.eo 
 # 80 members (1 type at a time)
 #SBATCH --ntasks=80 
 #SBATCH --time=04:00:00


### PR DESCRIPTION
My understanding is that we should not need to change
any CAM or CLM external forcing files when starting 2016.
That includes SSTs, aerosols, volcanoes, ...
But confirmation of that is welcome.
Also make use of the checklist on the DAReS G-doc page,
if that would be helpful.

repack_project.csh
> Changed year to archive 2015 yearly files to Campaign Storage