### PR TITLE
Request to run 2018-11.  Minor script changes.

### DIFF
--- a/Buildconf/cplconf/atm_modelio.nml_0001
+++ b/Buildconf/cplconf/atm_modelio.nml_0001
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/atm"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "atm_0001.log.200615-200541"
+  logfile = "atm_0001.log.200618-102248"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/Buildconf/cplconf/atm_modelio.nml_0002
+++ b/Buildconf/cplconf/atm_modelio.nml_0002
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/atm"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "atm_0002.log.200615-200541"
+  logfile = "atm_0002.log.200618-102248"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/Buildconf/cplconf/cpl_modelio.nml_0001
+++ b/Buildconf/cplconf/cpl_modelio.nml_0001
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/cpl"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "cpl_0001.log.200615-200541"
+  logfile = "cpl_0001.log.200618-102248"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/Buildconf/cplconf/cpl_modelio.nml_0002
+++ b/Buildconf/cplconf/cpl_modelio.nml_0002
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/cpl"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "cpl_0002.log.200615-200541"
+  logfile = "cpl_0002.log.200618-102248"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/Buildconf/cplconf/esp_modelio.nml_0001
+++ b/Buildconf/cplconf/esp_modelio.nml_0001
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/esp"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "esp_0001.log.200615-200541"
+  logfile = "esp_0001.log.200618-102248"
 /
 &pio_inparm
   pio_netcdf_format = ""

--- a/Buildconf/cplconf/esp_modelio.nml_0002
+++ b/Buildconf/cplconf/esp_modelio.nml_0002
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/esp"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "esp_0002.log.200615-200541"
+  logfile = "esp_0002.log.200618-102248"
 /
 &pio_inparm
   pio_netcdf_format = ""

--- a/Buildconf/cplconf/glc_modelio.nml_0001
+++ b/Buildconf/cplconf/glc_modelio.nml_0001
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/glc"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "glc_0001.log.200615-200541"
+  logfile = "glc_0001.log.200618-102248"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/Buildconf/cplconf/glc_modelio.nml_0002
+++ b/Buildconf/cplconf/glc_modelio.nml_0002
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/glc"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "glc_0002.log.200615-200541"
+  logfile = "glc_0002.log.200618-102248"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/Buildconf/cplconf/ice_modelio.nml_0001
+++ b/Buildconf/cplconf/ice_modelio.nml_0001
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/ice"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "ice_0001.log.200615-200541"
+  logfile = "ice_0001.log.200618-102248"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/Buildconf/cplconf/ice_modelio.nml_0002
+++ b/Buildconf/cplconf/ice_modelio.nml_0002
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/ice"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "ice_0002.log.200615-200541"
+  logfile = "ice_0002.log.200618-102248"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/Buildconf/cplconf/lnd_modelio.nml_0001
+++ b/Buildconf/cplconf/lnd_modelio.nml_0001
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/lnd"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "lnd_0001.log.200615-200541"
+  logfile = "lnd_0001.log.200618-102248"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/Buildconf/cplconf/lnd_modelio.nml_0002
+++ b/Buildconf/cplconf/lnd_modelio.nml_0002
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/lnd"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "lnd_0002.log.200615-200541"
+  logfile = "lnd_0002.log.200618-102248"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/Buildconf/cplconf/ocn_modelio.nml_0001
+++ b/Buildconf/cplconf/ocn_modelio.nml_0001
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/ocn"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "ocn_0001.log.200615-200541"
+  logfile = "ocn_0001.log.200618-102248"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/Buildconf/cplconf/ocn_modelio.nml_0002
+++ b/Buildconf/cplconf/ocn_modelio.nml_0002
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/ocn"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "ocn_0002.log.200615-200541"
+  logfile = "ocn_0002.log.200618-102248"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/Buildconf/cplconf/rof_modelio.nml_0001
+++ b/Buildconf/cplconf/rof_modelio.nml_0001
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/rof"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "rof_0001.log.200615-200541"
+  logfile = "rof_0001.log.200618-102248"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/Buildconf/cplconf/rof_modelio.nml_0002
+++ b/Buildconf/cplconf/rof_modelio.nml_0002
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/rof"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "rof_0002.log.200615-200541"
+  logfile = "rof_0002.log.200618-102248"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/Buildconf/cplconf/wav_modelio.nml_0001
+++ b/Buildconf/cplconf/wav_modelio.nml_0001
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/wav"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "wav_0001.log.200615-200541"
+  logfile = "wav_0001.log.200618-102248"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/Buildconf/cplconf/wav_modelio.nml_0002
+++ b/Buildconf/cplconf/wav_modelio.nml_0002
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/wav"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "wav_0002.log.200615-200541"
+  logfile = "wav_0002.log.200618-102248"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/CaseDocs/atm_modelio.nml_0001
+++ b/CaseDocs/atm_modelio.nml_0001
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/atm"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "atm_0001.log.200615-200541"
+  logfile = "atm_0001.log.200618-102248"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/CaseDocs/atm_modelio.nml_0002
+++ b/CaseDocs/atm_modelio.nml_0002
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/atm"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "atm_0002.log.200615-200541"
+  logfile = "atm_0002.log.200618-102248"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/CaseDocs/cpl_modelio.nml_0001
+++ b/CaseDocs/cpl_modelio.nml_0001
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/cpl"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "cpl_0001.log.200615-200541"
+  logfile = "cpl_0001.log.200618-102248"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/CaseDocs/cpl_modelio.nml_0002
+++ b/CaseDocs/cpl_modelio.nml_0002
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/cpl"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "cpl_0002.log.200615-200541"
+  logfile = "cpl_0002.log.200618-102248"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/CaseDocs/esp_modelio.nml_0001
+++ b/CaseDocs/esp_modelio.nml_0001
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/esp"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "esp_0001.log.200615-200541"
+  logfile = "esp_0001.log.200618-102248"
 /
 &pio_inparm
   pio_netcdf_format = ""

--- a/CaseDocs/esp_modelio.nml_0002
+++ b/CaseDocs/esp_modelio.nml_0002
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/esp"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "esp_0002.log.200615-200541"
+  logfile = "esp_0002.log.200618-102248"
 /
 &pio_inparm
   pio_netcdf_format = ""

--- a/CaseDocs/glc_modelio.nml_0001
+++ b/CaseDocs/glc_modelio.nml_0001
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/glc"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "glc_0001.log.200615-200541"
+  logfile = "glc_0001.log.200618-102248"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/CaseDocs/glc_modelio.nml_0002
+++ b/CaseDocs/glc_modelio.nml_0002
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/glc"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "glc_0002.log.200615-200541"
+  logfile = "glc_0002.log.200618-102248"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/CaseDocs/ice_modelio.nml_0001
+++ b/CaseDocs/ice_modelio.nml_0001
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/ice"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "ice_0001.log.200615-200541"
+  logfile = "ice_0001.log.200618-102248"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/CaseDocs/ice_modelio.nml_0002
+++ b/CaseDocs/ice_modelio.nml_0002
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/ice"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "ice_0002.log.200615-200541"
+  logfile = "ice_0002.log.200618-102248"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/CaseDocs/lnd_modelio.nml_0001
+++ b/CaseDocs/lnd_modelio.nml_0001
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/lnd"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "lnd_0001.log.200615-200541"
+  logfile = "lnd_0001.log.200618-102248"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/CaseDocs/lnd_modelio.nml_0002
+++ b/CaseDocs/lnd_modelio.nml_0002
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/lnd"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "lnd_0002.log.200615-200541"
+  logfile = "lnd_0002.log.200618-102248"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/CaseDocs/ocn_modelio.nml_0001
+++ b/CaseDocs/ocn_modelio.nml_0001
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/ocn"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "ocn_0001.log.200615-200541"
+  logfile = "ocn_0001.log.200618-102248"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/CaseDocs/ocn_modelio.nml_0002
+++ b/CaseDocs/ocn_modelio.nml_0002
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/ocn"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "ocn_0002.log.200615-200541"
+  logfile = "ocn_0002.log.200618-102248"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/CaseDocs/rof_modelio.nml_0001
+++ b/CaseDocs/rof_modelio.nml_0001
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/rof"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "rof_0001.log.200615-200541"
+  logfile = "rof_0001.log.200618-102248"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/CaseDocs/rof_modelio.nml_0002
+++ b/CaseDocs/rof_modelio.nml_0002
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/rof"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "rof_0002.log.200615-200541"
+  logfile = "rof_0002.log.200618-102248"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/CaseDocs/wav_modelio.nml_0001
+++ b/CaseDocs/wav_modelio.nml_0001
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/wav"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "wav_0001.log.200615-200541"
+  logfile = "wav_0001.log.200618-102248"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/CaseDocs/wav_modelio.nml_0002
+++ b/CaseDocs/wav_modelio.nml_0002
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/wav"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "wav_0002.log.200615-200541"
+  logfile = "wav_0002.log.200618-102248"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/call_mv_to_cs.csh
+++ b/call_mv_to_cs.csh
@@ -3,16 +3,16 @@
 # Last mod time before this comment was 2019-9-7.
 # ? Script to use with qcmd?
 
-set y_m = 2011-08
+set y_m = 2018-10
 
-./mv_to_campaign.csh $casename $y_m ${s}/${casename}/archive/rest/$y_m \
+./mv_to_campaign.csh  $y_m ${s}/${casename}/archive/rest/$y_m \
                   /gpfs/csfs1/cisl/dares/Reanalyses/${casename}/rest
 
-./mv_to_campaign.csh $casename $y_m ${s}/${casename}/archive/esp/hist/$y_m \
+./mv_to_campaign.csh  $y_m ${s}/${casename}/archive/esp/hist/$y_m \
                   /gpfs/csfs1/cisl/dares/Reanalyses/${casename}/esp/hist
 
-./mv_to_campaign.csh $casename $y_m ${s}/${casename}/archive/atm/hist/$y_m \
+./mv_to_campaign.csh  $y_m ${s}/${casename}/archive/atm/hist/$y_m \
                   /gpfs/csfs1/cisl/dares/Reanalyses/${casename}/atm/hist
 
-./mv_to_campaign.csh $casename $y_m ${s}/${casename}/archive/logs/$y_m \
+./mv_to_campaign.csh  $y_m ${s}/${casename}/archive/logs/$y_m \
                   /gpfs/csfs1/cisl/dares/Reanalyses/${casename}/logs

--- a/env_run.xml
+++ b/env_run.xml
@@ -252,7 +252,7 @@
       timing tests.
     </desc>
     </entry>
-    <entry id="JOB_IDS" value="case.run:2772195.chadmin1.ib0.cheyenne.ucar.edu, case.st_archive:2772196.chadmin1.ib0.cheyenne.ucar.edu">
+    <entry id="JOB_IDS" value="case.run:2798640.chadmin1.ib0.cheyenne.ucar.edu, case.st_archive:2798641.chadmin1.ib0.cheyenne.ucar.edu">
       <type>char</type>
       <desc>List of job ids for most recent case.submit</desc>
     </entry>
@@ -1131,7 +1131,7 @@
         <value compclass="LND">FALSE</value>
       </values>
     </entry>
-    <entry id="DATA_ASSIMILATION_CYCLES" value="124">
+    <entry id="DATA_ASSIMILATION_CYCLES" value="120">
       <type>integer</type>
       <valid_values/>
       <desc> Number of model run - data assimilation steps to complete </desc>

--- a/mv_to_campaign.csh
+++ b/mv_to_campaign.csh
@@ -88,7 +88,8 @@ echo Copy $SRC_DIR to campaign storage $CS_DIR >>& $glog
 # For example 
 # > globus endpoint activate --help
 # will show obscura such as --myproxy (below).
-module load gnu python
+# module load gnu python
+module load gnu python/3.6.8
 
 # Enable the NCAR Python Library (NPL) virtual environment 
 # This command activates the 'globus' command

--- a/submit_compress.csh
+++ b/submit_compress.csh
@@ -54,7 +54,7 @@ source data_scripts.csh
 
 set comp_cmd      = 'gzip '
 # set comp_cmd      = 'gzip -k'
-set ymds          = 2016-08-01-00000
+set ymds          = 2018-10-01-00000
 set data_dir      = ${data_DOUT_S_ROOT}/rest/${ymds}
 
 # set sets          = (cpl)


### PR DESCRIPTION
call_mv_to_cs.csh
> Removed an argument to mv_to_campaign.csh which is not needed
> after the implementation of data_scripts.csh.

mv_to_campaign.csh
> Adapt to the new default python on casper by explicitly referring
> to the one we have been using; 3.6.8.  After 2018 (2019?) is finished,
> we should test the script with the new python.

submit_compress.csh
> Change the date to process.  That restart file directory needed
> to be compressed before processing by repack_st_arch.csh.