### PR TITLE
Request to rerun 2019-09-30 and 2019-10 to replace lost files.

### DIFF
--- a/Buildconf/cplconf/atm_modelio.nml_0001
+++ b/Buildconf/cplconf/atm_modelio.nml_0001
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/atm"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "atm_0001.log.200810-132753"
+  logfile = "atm_0001.log.200817-070009"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/Buildconf/cplconf/atm_modelio.nml_0002
+++ b/Buildconf/cplconf/atm_modelio.nml_0002
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/atm"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "atm_0002.log.200810-132753"
+  logfile = "atm_0002.log.200817-070009"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/Buildconf/cplconf/cpl_modelio.nml_0001
+++ b/Buildconf/cplconf/cpl_modelio.nml_0001
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/cpl"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "cpl_0001.log.200810-132753"
+  logfile = "cpl_0001.log.200817-070009"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/Buildconf/cplconf/cpl_modelio.nml_0002
+++ b/Buildconf/cplconf/cpl_modelio.nml_0002
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/cpl"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "cpl_0002.log.200810-132753"
+  logfile = "cpl_0002.log.200817-070009"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/Buildconf/cplconf/esp_modelio.nml_0001
+++ b/Buildconf/cplconf/esp_modelio.nml_0001
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/esp"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "esp_0001.log.200810-132753"
+  logfile = "esp_0001.log.200817-070009"
 /
 &pio_inparm
   pio_netcdf_format = ""

--- a/Buildconf/cplconf/esp_modelio.nml_0002
+++ b/Buildconf/cplconf/esp_modelio.nml_0002
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/esp"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "esp_0002.log.200810-132753"
+  logfile = "esp_0002.log.200817-070009"
 /
 &pio_inparm
   pio_netcdf_format = ""

--- a/Buildconf/cplconf/glc_modelio.nml_0001
+++ b/Buildconf/cplconf/glc_modelio.nml_0001
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/glc"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "glc_0001.log.200810-132753"
+  logfile = "glc_0001.log.200817-070009"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/Buildconf/cplconf/glc_modelio.nml_0002
+++ b/Buildconf/cplconf/glc_modelio.nml_0002
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/glc"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "glc_0002.log.200810-132753"
+  logfile = "glc_0002.log.200817-070009"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/Buildconf/cplconf/ice_modelio.nml_0001
+++ b/Buildconf/cplconf/ice_modelio.nml_0001
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/ice"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "ice_0001.log.200810-132753"
+  logfile = "ice_0001.log.200817-070009"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/Buildconf/cplconf/ice_modelio.nml_0002
+++ b/Buildconf/cplconf/ice_modelio.nml_0002
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/ice"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "ice_0002.log.200810-132753"
+  logfile = "ice_0002.log.200817-070009"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/Buildconf/cplconf/lnd_modelio.nml_0001
+++ b/Buildconf/cplconf/lnd_modelio.nml_0001
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/lnd"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "lnd_0001.log.200810-132753"
+  logfile = "lnd_0001.log.200817-070009"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/Buildconf/cplconf/lnd_modelio.nml_0002
+++ b/Buildconf/cplconf/lnd_modelio.nml_0002
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/lnd"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "lnd_0002.log.200810-132753"
+  logfile = "lnd_0002.log.200817-070009"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/Buildconf/cplconf/ocn_modelio.nml_0001
+++ b/Buildconf/cplconf/ocn_modelio.nml_0001
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/ocn"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "ocn_0001.log.200810-132753"
+  logfile = "ocn_0001.log.200817-070009"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/Buildconf/cplconf/ocn_modelio.nml_0002
+++ b/Buildconf/cplconf/ocn_modelio.nml_0002
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/ocn"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "ocn_0002.log.200810-132753"
+  logfile = "ocn_0002.log.200817-070009"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/Buildconf/cplconf/rof_modelio.nml_0001
+++ b/Buildconf/cplconf/rof_modelio.nml_0001
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/rof"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "rof_0001.log.200810-132753"
+  logfile = "rof_0001.log.200817-070009"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/Buildconf/cplconf/rof_modelio.nml_0002
+++ b/Buildconf/cplconf/rof_modelio.nml_0002
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/rof"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "rof_0002.log.200810-132753"
+  logfile = "rof_0002.log.200817-070009"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/Buildconf/cplconf/wav_modelio.nml_0001
+++ b/Buildconf/cplconf/wav_modelio.nml_0001
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/wav"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "wav_0001.log.200810-132753"
+  logfile = "wav_0001.log.200817-070009"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/Buildconf/cplconf/wav_modelio.nml_0002
+++ b/Buildconf/cplconf/wav_modelio.nml_0002
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/wav"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "wav_0002.log.200810-132753"
+  logfile = "wav_0002.log.200817-070009"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/CaseDocs/atm_modelio.nml_0001
+++ b/CaseDocs/atm_modelio.nml_0001
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/atm"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "atm_0001.log.200810-132753"
+  logfile = "atm_0001.log.200817-070009"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/CaseDocs/atm_modelio.nml_0002
+++ b/CaseDocs/atm_modelio.nml_0002
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/atm"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "atm_0002.log.200810-132753"
+  logfile = "atm_0002.log.200817-070009"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/CaseDocs/cpl_modelio.nml_0001
+++ b/CaseDocs/cpl_modelio.nml_0001
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/cpl"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "cpl_0001.log.200810-132753"
+  logfile = "cpl_0001.log.200817-070009"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/CaseDocs/cpl_modelio.nml_0002
+++ b/CaseDocs/cpl_modelio.nml_0002
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/cpl"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "cpl_0002.log.200810-132753"
+  logfile = "cpl_0002.log.200817-070009"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/CaseDocs/esp_modelio.nml_0001
+++ b/CaseDocs/esp_modelio.nml_0001
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/esp"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "esp_0001.log.200810-132753"
+  logfile = "esp_0001.log.200817-070009"
 /
 &pio_inparm
   pio_netcdf_format = ""

--- a/CaseDocs/esp_modelio.nml_0002
+++ b/CaseDocs/esp_modelio.nml_0002
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/esp"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "esp_0002.log.200810-132753"
+  logfile = "esp_0002.log.200817-070009"
 /
 &pio_inparm
   pio_netcdf_format = ""

--- a/CaseDocs/glc_modelio.nml_0001
+++ b/CaseDocs/glc_modelio.nml_0001
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/glc"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "glc_0001.log.200810-132753"
+  logfile = "glc_0001.log.200817-070009"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/CaseDocs/glc_modelio.nml_0002
+++ b/CaseDocs/glc_modelio.nml_0002
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/glc"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "glc_0002.log.200810-132753"
+  logfile = "glc_0002.log.200817-070009"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/CaseDocs/ice_modelio.nml_0001
+++ b/CaseDocs/ice_modelio.nml_0001
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/ice"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "ice_0001.log.200810-132753"
+  logfile = "ice_0001.log.200817-070009"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/CaseDocs/ice_modelio.nml_0002
+++ b/CaseDocs/ice_modelio.nml_0002
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/ice"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "ice_0002.log.200810-132753"
+  logfile = "ice_0002.log.200817-070009"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/CaseDocs/lnd_modelio.nml_0001
+++ b/CaseDocs/lnd_modelio.nml_0001
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/lnd"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "lnd_0001.log.200810-132753"
+  logfile = "lnd_0001.log.200817-070009"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/CaseDocs/lnd_modelio.nml_0002
+++ b/CaseDocs/lnd_modelio.nml_0002
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/lnd"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "lnd_0002.log.200810-132753"
+  logfile = "lnd_0002.log.200817-070009"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/CaseDocs/ocn_modelio.nml_0001
+++ b/CaseDocs/ocn_modelio.nml_0001
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/ocn"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "ocn_0001.log.200810-132753"
+  logfile = "ocn_0001.log.200817-070009"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/CaseDocs/ocn_modelio.nml_0002
+++ b/CaseDocs/ocn_modelio.nml_0002
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/ocn"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "ocn_0002.log.200810-132753"
+  logfile = "ocn_0002.log.200817-070009"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/CaseDocs/rof_modelio.nml_0001
+++ b/CaseDocs/rof_modelio.nml_0001
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/rof"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "rof_0001.log.200810-132753"
+  logfile = "rof_0001.log.200817-070009"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/CaseDocs/rof_modelio.nml_0002
+++ b/CaseDocs/rof_modelio.nml_0002
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/rof"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "rof_0002.log.200810-132753"
+  logfile = "rof_0002.log.200817-070009"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/CaseDocs/wav_modelio.nml_0001
+++ b/CaseDocs/wav_modelio.nml_0001
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/wav"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "wav_0001.log.200810-132753"
+  logfile = "wav_0001.log.200817-070009"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/CaseDocs/wav_modelio.nml_0002
+++ b/CaseDocs/wav_modelio.nml_0002
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/wav"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "wav_0002.log.200810-132753"
+  logfile = "wav_0002.log.200817-070009"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/env_batch.xml
+++ b/env_batch.xml
@@ -103,7 +103,7 @@
       <valid_values/>
       <desc>The machine wallclock setting.  Default determined in config_machines.xml can be overwritten by testing</desc>
     </entry>
-    <entry id="JOB_QUEUE" value="economy">
+    <entry id="JOB_QUEUE" value="premium">
       <type>char</type>
       <valid_values/>
       <desc>The machine queue in which to submit the job.  Default determined in config_machines.xml can be overwritten by testing</desc>
@@ -112,7 +112,7 @@
       <type>char</type>
       <desc>Store user override for walltime</desc>
     </entry>
-    <entry id="USER_REQUESTED_QUEUE" value="economy">
+    <entry id="USER_REQUESTED_QUEUE" value="premium">
       <type>char</type>
       <desc>Store user override for queue</desc>
     </entry>

--- a/env_run.xml
+++ b/env_run.xml
@@ -252,7 +252,7 @@
       timing tests.
     </desc>
     </entry>
-    <entry id="JOB_IDS" value="case.run:3465170.chadmin1.ib0.cheyenne.ucar.edu, case.st_archive:3465171.chadmin1.ib0.cheyenne.ucar.edu">
+    <entry id="JOB_IDS" value="case.run:3565808.chadmin1.ib0.cheyenne.ucar.edu, case.st_archive:3565809.chadmin1.ib0.cheyenne.ucar.edu">
       <type>char</type>
       <desc>List of job ids for most recent case.submit</desc>
     </entry>

--- a/repack_project.csh
+++ b/repack_project.csh
@@ -18,6 +18,8 @@
 # FIXME KEVIN - describe how this is supposed to be run/used.
 # >>> Run repack_st_arch.csh before running this script. <<<
 # >>> Log in to globus (see mv_to_campaign.csh for instructions).
+# >>> Purge extraneous files from $data_project_space/$data_CASE/esp/hist, 
+#     since (the new parts of) that whole directory will be archived.
 # >>> From a casper window (but not 'ssh'ed to data-access.ucar.edu)
 #     submit this script from the CESM CASEROOT directory. <<<
 
@@ -41,8 +43,8 @@
 #SBATCH --job-name=repack_project
 # Output standard output and error to a file named with 
 # the job-name and the jobid.
-#SBATCH -o %x_%j_2018.eo 
-#SBATCH -e %x_%j_2018.eo 
+#SBATCH -o %x_%j_2019.eo 
+#SBATCH -e %x_%j_2019.eo 
 # 80 members (1 type at a time)
 #SBATCH --ntasks=80 
 #SBATCH --time=04:00:00

--- a/setup_advanced_Rean.original
+++ b/setup_advanced_Rean.original
@@ -1307,6 +1307,16 @@ else     # CONTINUE_RUN == FALSE
    echo "All files set to run the FIRST experiment step using (ref)time" $init_time
 
 endif
+
+ls *inf*${restart_time}* >& /dev/null
+if ($status != 0) then 
+   echo ""
+   echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+   echo "WARNING:  no inflation files were fond for \$restart_time"
+   echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+   echo ""
+endif
+
 exit 0
 
 EndOfText

--- a/stage_cesm_files
+++ b/stage_cesm_files
@@ -11,7 +11,7 @@
 #  2) be sure 'restart_time' is set to the day and time from which you want to
 #     restart, if not the initial time.
 
-set restart_time = 2018-02-05-64800
+set restart_time = 2019-09-30-00000
 
 # ---------------------------------------------------------
 # Get the settings for this case from the CESM environment
@@ -158,5 +158,15 @@ else     # CONTINUE_RUN == FALSE
    echo "All files set to run the FIRST experiment step using (ref)time" 2011-01-01-00000
 
 endif
+
+ls *inf*${restart_time}* >& /dev/null
+if ($status != 0) then 
+   echo ""
+   echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+   echo "WARNING:  no inflation files were fond for $restart_time"
+   echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+   echo ""
+endif
+
 exit 0
 

--- a/tar_obs_seq_qcmd.csh
+++ b/tar_obs_seq_qcmd.csh
@@ -7,7 +7,7 @@
 #  Usage: edit this file to change date
 #         > remote tar_obs_seq_qcmd.csh
 
-set year_mm  = 2019-01
+set year_mm  = 2019-10
 set case     = f.e21.FHIST_BGC.f09_025.CAM6assim.011
 set proj_dir = "/glade/p/nsc/ncis0006/Reanalyses/${case}/esp/hist/${year_mm}"
 set file     = "${case}.cam_obs_seq_final.${year_mm}.tgz"
@@ -19,7 +19,7 @@ set cmnd = "tar -c -z -f ${proj_dir}/${file} "'*obs_seq*'"${year_mm}"'*'
 cd /glade/scratch/raeder/${case}/archive/esp/hist
 
 echo "$cmnd" >& tar_obs_seq.${year_mm}.log.$$
-qcmd -A NCIS0006 -l walltime=6:00:00 -q share \
+qcmd -A P86850054 -l walltime=6:00:00 -q share \
      -l select=1:ncpus=1:mpiprocs=1 \
      -- "$cmnd"  >>& tar_obs_seq.${year_mm}.log.$$
 # 


### PR DESCRIPTION
Since this is not the normal workflow (I'm rerunning a month from archived ICs),
it's worth some extra scrutiny.  If you have time and interest, check out
/glade/work/raeder/Exp/f.e21.FHIST_BGC.f09_025.CAM6assim.011
and 
/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run
andor ask me questions about how I set it up.
I'm running a single day (premium) first to make the run of October
match the standard, whole month format.  It's also less likely that
32 days would finish in 1 job, and it would be little messier to have a job
with 1 day of Sep and not all of the days of Oct.  I'll run Oct in economy.

env_batch.xml
>  Running the last day of 2019-09 to create the ICs for 2019-10 in premium
>  to set up 2019-10 sooner rather than later.

repack_project.csh
>  Helpful comment.

stage_cesm_files
>  Added section to check for the presence of inflation restart files.