### PR TITLE
Request to rerun 2019-09-30, first cycle, for debugging.

### DIFF
--- a/Buildconf/cplconf/atm_modelio.nml_0001
+++ b/Buildconf/cplconf/atm_modelio.nml_0001
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/atm"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "atm_0001.log.200817-070009"
+  logfile = "atm_0001.log.200824-144539"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/Buildconf/cplconf/atm_modelio.nml_0002
+++ b/Buildconf/cplconf/atm_modelio.nml_0002
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/atm"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "atm_0002.log.200817-070009"
+  logfile = "atm_0002.log.200824-144539"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/Buildconf/cplconf/cpl_modelio.nml_0001
+++ b/Buildconf/cplconf/cpl_modelio.nml_0001
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/cpl"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "cpl_0001.log.200817-070009"
+  logfile = "cpl_0001.log.200824-144539"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/Buildconf/cplconf/cpl_modelio.nml_0002
+++ b/Buildconf/cplconf/cpl_modelio.nml_0002
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/cpl"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "cpl_0002.log.200817-070009"
+  logfile = "cpl_0002.log.200824-144539"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/Buildconf/cplconf/esp_modelio.nml_0001
+++ b/Buildconf/cplconf/esp_modelio.nml_0001
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/esp"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "esp_0001.log.200817-070009"
+  logfile = "esp_0001.log.200824-144539"
 /
 &pio_inparm
   pio_netcdf_format = ""

--- a/Buildconf/cplconf/esp_modelio.nml_0002
+++ b/Buildconf/cplconf/esp_modelio.nml_0002
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/esp"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "esp_0002.log.200817-070009"
+  logfile = "esp_0002.log.200824-144539"
 /
 &pio_inparm
   pio_netcdf_format = ""

--- a/Buildconf/cplconf/glc_modelio.nml_0001
+++ b/Buildconf/cplconf/glc_modelio.nml_0001
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/glc"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "glc_0001.log.200817-070009"
+  logfile = "glc_0001.log.200824-144539"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/Buildconf/cplconf/glc_modelio.nml_0002
+++ b/Buildconf/cplconf/glc_modelio.nml_0002
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/glc"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "glc_0002.log.200817-070009"
+  logfile = "glc_0002.log.200824-144539"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/Buildconf/cplconf/ice_modelio.nml_0001
+++ b/Buildconf/cplconf/ice_modelio.nml_0001
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/ice"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "ice_0001.log.200817-070009"
+  logfile = "ice_0001.log.200824-144539"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/Buildconf/cplconf/ice_modelio.nml_0002
+++ b/Buildconf/cplconf/ice_modelio.nml_0002
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/ice"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "ice_0002.log.200817-070009"
+  logfile = "ice_0002.log.200824-144539"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/Buildconf/cplconf/lnd_modelio.nml_0001
+++ b/Buildconf/cplconf/lnd_modelio.nml_0001
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/lnd"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "lnd_0001.log.200817-070009"
+  logfile = "lnd_0001.log.200824-144539"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/Buildconf/cplconf/lnd_modelio.nml_0002
+++ b/Buildconf/cplconf/lnd_modelio.nml_0002
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/lnd"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "lnd_0002.log.200817-070009"
+  logfile = "lnd_0002.log.200824-144539"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/Buildconf/cplconf/ocn_modelio.nml_0001
+++ b/Buildconf/cplconf/ocn_modelio.nml_0001
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/ocn"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "ocn_0001.log.200817-070009"
+  logfile = "ocn_0001.log.200824-144539"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/Buildconf/cplconf/ocn_modelio.nml_0002
+++ b/Buildconf/cplconf/ocn_modelio.nml_0002
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/ocn"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "ocn_0002.log.200817-070009"
+  logfile = "ocn_0002.log.200824-144539"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/Buildconf/cplconf/rof_modelio.nml_0001
+++ b/Buildconf/cplconf/rof_modelio.nml_0001
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/rof"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "rof_0001.log.200817-070009"
+  logfile = "rof_0001.log.200824-144539"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/Buildconf/cplconf/rof_modelio.nml_0002
+++ b/Buildconf/cplconf/rof_modelio.nml_0002
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/rof"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "rof_0002.log.200817-070009"
+  logfile = "rof_0002.log.200824-144539"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/Buildconf/cplconf/wav_modelio.nml_0001
+++ b/Buildconf/cplconf/wav_modelio.nml_0001
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/wav"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "wav_0001.log.200817-070009"
+  logfile = "wav_0001.log.200824-144539"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/Buildconf/cplconf/wav_modelio.nml_0002
+++ b/Buildconf/cplconf/wav_modelio.nml_0002
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/wav"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "wav_0002.log.200817-070009"
+  logfile = "wav_0002.log.200824-144539"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/CaseDocs/atm_modelio.nml_0001
+++ b/CaseDocs/atm_modelio.nml_0001
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/atm"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "atm_0001.log.200817-070009"
+  logfile = "atm_0001.log.200824-144539"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/CaseDocs/atm_modelio.nml_0002
+++ b/CaseDocs/atm_modelio.nml_0002
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/atm"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "atm_0002.log.200817-070009"
+  logfile = "atm_0002.log.200824-144539"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/CaseDocs/cpl_modelio.nml_0001
+++ b/CaseDocs/cpl_modelio.nml_0001
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/cpl"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "cpl_0001.log.200817-070009"
+  logfile = "cpl_0001.log.200824-144539"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/CaseDocs/cpl_modelio.nml_0002
+++ b/CaseDocs/cpl_modelio.nml_0002
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/cpl"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "cpl_0002.log.200817-070009"
+  logfile = "cpl_0002.log.200824-144539"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/CaseDocs/esp_modelio.nml_0001
+++ b/CaseDocs/esp_modelio.nml_0001
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/esp"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "esp_0001.log.200817-070009"
+  logfile = "esp_0001.log.200824-144539"
 /
 &pio_inparm
   pio_netcdf_format = ""

--- a/CaseDocs/esp_modelio.nml_0002
+++ b/CaseDocs/esp_modelio.nml_0002
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/esp"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "esp_0002.log.200817-070009"
+  logfile = "esp_0002.log.200824-144539"
 /
 &pio_inparm
   pio_netcdf_format = ""

--- a/CaseDocs/glc_modelio.nml_0001
+++ b/CaseDocs/glc_modelio.nml_0001
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/glc"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "glc_0001.log.200817-070009"
+  logfile = "glc_0001.log.200824-144539"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/CaseDocs/glc_modelio.nml_0002
+++ b/CaseDocs/glc_modelio.nml_0002
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/glc"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "glc_0002.log.200817-070009"
+  logfile = "glc_0002.log.200824-144539"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/CaseDocs/ice_modelio.nml_0001
+++ b/CaseDocs/ice_modelio.nml_0001
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/ice"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "ice_0001.log.200817-070009"
+  logfile = "ice_0001.log.200824-144539"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/CaseDocs/ice_modelio.nml_0002
+++ b/CaseDocs/ice_modelio.nml_0002
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/ice"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "ice_0002.log.200817-070009"
+  logfile = "ice_0002.log.200824-144539"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/CaseDocs/lnd_modelio.nml_0001
+++ b/CaseDocs/lnd_modelio.nml_0001
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/lnd"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "lnd_0001.log.200817-070009"
+  logfile = "lnd_0001.log.200824-144539"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/CaseDocs/lnd_modelio.nml_0002
+++ b/CaseDocs/lnd_modelio.nml_0002
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/lnd"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "lnd_0002.log.200817-070009"
+  logfile = "lnd_0002.log.200824-144539"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/CaseDocs/ocn_modelio.nml_0001
+++ b/CaseDocs/ocn_modelio.nml_0001
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/ocn"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "ocn_0001.log.200817-070009"
+  logfile = "ocn_0001.log.200824-144539"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/CaseDocs/ocn_modelio.nml_0002
+++ b/CaseDocs/ocn_modelio.nml_0002
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/ocn"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "ocn_0002.log.200817-070009"
+  logfile = "ocn_0002.log.200824-144539"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/CaseDocs/rof_modelio.nml_0001
+++ b/CaseDocs/rof_modelio.nml_0001
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/rof"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "rof_0001.log.200817-070009"
+  logfile = "rof_0001.log.200824-144539"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/CaseDocs/rof_modelio.nml_0002
+++ b/CaseDocs/rof_modelio.nml_0002
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/rof"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "rof_0002.log.200817-070009"
+  logfile = "rof_0002.log.200824-144539"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/CaseDocs/wav_modelio.nml_0001
+++ b/CaseDocs/wav_modelio.nml_0001
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/wav"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "wav_0001.log.200817-070009"
+  logfile = "wav_0001.log.200824-144539"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/CaseDocs/wav_modelio.nml_0002
+++ b/CaseDocs/wav_modelio.nml_0002
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/wav"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "wav_0002.log.200817-070009"
+  logfile = "wav_0002.log.200824-144539"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/assimilate.csh
+++ b/assimilate.csh
@@ -88,6 +88,14 @@ else if ($?PBS_NODEFILE) then
    echo "tasks_per_node : $NUMTASKS_PERNODE"
    echo " "
 
+   # KDR; debugging differences between 2019-09-30-21600 
+   # before and after cheyenne July down time.
+   # Mick says the old MPT, which was used to build and run the old filter,
+   # was mpt/2.21.
+   module load mpt/2.21
+   echo "Modules used for this assimilation:"
+   module list
+
 else if ($?LSB_HOSTS) then
 
    # LSF environment variables:
@@ -637,6 +645,8 @@ if ($USING_PRIOR_INFLATION == true) then
    else
       # Look for the output from the previous assimilation (or fill_inflation_restart)
       # If inflation files exists, use them as input for this assimilation
+      # TODO: This should probably look for a date, instead of relying on the files
+      #       we want being the youngest in the directory.
       echo "Gathering inflation names at " `date --rfc-3339=ns`
       (${LIST} -rt1 *.dart.rh.${scomp}_output_priorinf_mean* | tail -n 1 >! latestfile) > & /dev/null
       (${LIST} -rt1 *.dart.rh.${scomp}_output_priorinf_sd*   | tail -n 1 >> latestfile) > & /dev/null

--- a/assimilate.csh
+++ b/assimilate.csh
@@ -92,9 +92,10 @@ else if ($?PBS_NODEFILE) then
    # before and after cheyenne July down time.
    # Mick says the old MPT, which was used to build and run the old filter,
    # was mpt/2.21.
-   module load mpt/2.21
+   module swap mpt/2.21
    echo "Modules used for this assimilation:"
    module list
+   echo "-----------------------------------"
 
 else if ($?LSB_HOSTS) then
 
@@ -149,6 +150,17 @@ setenv TOTALPES                  `./xmlquery TOTALPES      --value`
 setenv CONT_RUN                  `./xmlquery CONTINUE_RUN  --value`
 setenv CHECK_TIMING              `./xmlquery CHECK_TIMING  --value`
 setenv DATA_ASSIMILATION_CYCLES  `./xmlquery DATA_ASSIMILATION_CYCLES --value`
+
+echo "============================================================="
+echo "Brian's suggestions of checks:"
+echo "which mpiexec_mpt"
+which mpiexec_mpt
+echo "mpif90 -show"
+mpif90 -show
+echo "ldd ./filter.exe"
+ldd ${EXEROOT}/filter.exe
+echo "End of module checking section"
+echo "============================================================="
 
 # Switch CESM's timer script off for the rest of the forecasts of this job.
 # The timer takes a significant amount of time, which grows by ~15 s

--- a/env_batch.xml
+++ b/env_batch.xml
@@ -98,7 +98,7 @@
       <valid_values/>
       <desc>Override the batch submit command this job. Do not include executable or dependencies</desc>
     </entry>
-    <entry id="JOB_WALLCLOCK_TIME" value="12:00:00">
+    <entry id="JOB_WALLCLOCK_TIME" value="00:17:00">
       <type>char</type>
       <valid_values/>
       <desc>The machine wallclock setting.  Default determined in config_machines.xml can be overwritten by testing</desc>
@@ -108,7 +108,7 @@
       <valid_values/>
       <desc>The machine queue in which to submit the job.  Default determined in config_machines.xml can be overwritten by testing</desc>
     </entry>
-    <entry id="USER_REQUESTED_WALLTIME" value="12:00">
+    <entry id="USER_REQUESTED_WALLTIME" value="00:17">
       <type>char</type>
       <desc>Store user override for walltime</desc>
     </entry>

--- a/env_run.xml
+++ b/env_run.xml
@@ -252,7 +252,7 @@
       timing tests.
     </desc>
     </entry>
-    <entry id="JOB_IDS" value="case.run:3565808.chadmin1.ib0.cheyenne.ucar.edu, case.st_archive:3565809.chadmin1.ib0.cheyenne.ucar.edu">
+    <entry id="JOB_IDS" value="case.run:3702021.chadmin1.ib0.cheyenne.ucar.edu, case.st_archive:3702022.chadmin1.ib0.cheyenne.ucar.edu">
       <type>char</type>
       <desc>List of job ids for most recent case.submit</desc>
     </entry>
@@ -265,7 +265,7 @@
     </entry>
   </group>
   <group id="run_data_archive">
-    <entry id="DOUT_S" value="TRUE">
+    <entry id="DOUT_S" value="FALSE">
       <type>logical</type>
       <valid_values>TRUE,FALSE</valid_values>
       <desc>Logical to turn on short term archiving.
@@ -1131,12 +1131,12 @@
         <value compclass="LND">FALSE</value>
       </values>
     </entry>
-    <entry id="DATA_ASSIMILATION_CYCLES" value="4">
+    <entry id="DATA_ASSIMILATION_CYCLES" value="1">
       <type>integer</type>
       <valid_values/>
       <desc> Number of model run - data assimilation steps to complete </desc>
     </entry>
-    <entry id="DATA_ASSIMILATION_SCRIPT" value="/glade/work/raeder/Exp/f.e21.FHIST_BGC.f09_025.CAM6assim.011/assimilate.csh">
+    <entry id="DATA_ASSIMILATION_SCRIPT" value="/glade/work/raeder/Exp/f.e21.FHIST_BGC.f09_025.CAM6assim.011/no_assimilate.csh">
       <type>char</type>
       <valid_values/>
       <desc>External script to be run after model completion</desc>

--- a/pre_submit.csh
+++ b/pre_submit.csh
@@ -147,8 +147,8 @@ echo "$cycles cycles will be distributed among $resubmissions +1 jobs"
 # @ job_minutes = 10 + ( $cycles_per_job * ( 10 + (( $cycles_per_job * 10) / 70 )))
 # 12 hours: @ job_minutes = 720
 
-# @ job_minutes = ( $cycles_per_job * 7 ) + 10 
-@ job_minutes = 12 * 60
+@ job_minutes = ( $cycles_per_job * 7 ) + 10 
+# @ job_minutes = 12 * 60
 @ wall_hours  = $job_minutes / 60
 @ wall_mins   = $job_minutes % 60
 set wall_time = `printf %02d:%02d $wall_hours $wall_mins`


### PR DESCRIPTION
This will use the filter executable (circa 2020-3-2)
which was used for the first run of this cycle,
to see whether we can recreate the output.
The new version (circa 2020-7-28), doesn't.
I will run just the hindcast first, then the assimilation
as separate job(s), as needed for debugging.
I'll archive the hindcast results where I can reuse them.

assimilate.csh
>  Load the mpt module I used for the old cycle.
>  The new default is 2.22, although my login environment
>  has 2.21 loaded.

env_run.xml
>  I'm running just the hindcast in this job,

pre_submit.csh
>  Return this script to setting a good wall clock time for short
>  (debugging) runs.