### PR TITLE
Restoring run mode to a full cycle, plus improvements

### DIFF
--- a/Buildconf/cplconf/atm_modelio.nml_0001
+++ b/Buildconf/cplconf/atm_modelio.nml_0001
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/atm"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "atm_0001.log.200824-144539"
+  logfile = "atm_0001.log.200827-161946"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/Buildconf/cplconf/atm_modelio.nml_0002
+++ b/Buildconf/cplconf/atm_modelio.nml_0002
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/atm"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "atm_0002.log.200824-144539"
+  logfile = "atm_0002.log.200827-161946"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/Buildconf/cplconf/cpl_modelio.nml_0001
+++ b/Buildconf/cplconf/cpl_modelio.nml_0001
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/cpl"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "cpl_0001.log.200824-144539"
+  logfile = "cpl_0001.log.200827-161946"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/Buildconf/cplconf/cpl_modelio.nml_0002
+++ b/Buildconf/cplconf/cpl_modelio.nml_0002
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/cpl"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "cpl_0002.log.200824-144539"
+  logfile = "cpl_0002.log.200827-161946"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/Buildconf/cplconf/esp_modelio.nml_0001
+++ b/Buildconf/cplconf/esp_modelio.nml_0001
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/esp"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "esp_0001.log.200824-144539"
+  logfile = "esp_0001.log.200827-161946"
 /
 &pio_inparm
   pio_netcdf_format = ""

--- a/Buildconf/cplconf/esp_modelio.nml_0002
+++ b/Buildconf/cplconf/esp_modelio.nml_0002
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/esp"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "esp_0002.log.200824-144539"
+  logfile = "esp_0002.log.200827-161946"
 /
 &pio_inparm
   pio_netcdf_format = ""

--- a/Buildconf/cplconf/glc_modelio.nml_0001
+++ b/Buildconf/cplconf/glc_modelio.nml_0001
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/glc"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "glc_0001.log.200824-144539"
+  logfile = "glc_0001.log.200827-161946"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/Buildconf/cplconf/glc_modelio.nml_0002
+++ b/Buildconf/cplconf/glc_modelio.nml_0002
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/glc"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "glc_0002.log.200824-144539"
+  logfile = "glc_0002.log.200827-161946"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/Buildconf/cplconf/ice_modelio.nml_0001
+++ b/Buildconf/cplconf/ice_modelio.nml_0001
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/ice"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "ice_0001.log.200824-144539"
+  logfile = "ice_0001.log.200827-161946"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/Buildconf/cplconf/ice_modelio.nml_0002
+++ b/Buildconf/cplconf/ice_modelio.nml_0002
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/ice"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "ice_0002.log.200824-144539"
+  logfile = "ice_0002.log.200827-161946"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/Buildconf/cplconf/lnd_modelio.nml_0001
+++ b/Buildconf/cplconf/lnd_modelio.nml_0001
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/lnd"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "lnd_0001.log.200824-144539"
+  logfile = "lnd_0001.log.200827-161946"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/Buildconf/cplconf/lnd_modelio.nml_0002
+++ b/Buildconf/cplconf/lnd_modelio.nml_0002
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/lnd"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "lnd_0002.log.200824-144539"
+  logfile = "lnd_0002.log.200827-161946"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/Buildconf/cplconf/ocn_modelio.nml_0001
+++ b/Buildconf/cplconf/ocn_modelio.nml_0001
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/ocn"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "ocn_0001.log.200824-144539"
+  logfile = "ocn_0001.log.200827-161946"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/Buildconf/cplconf/ocn_modelio.nml_0002
+++ b/Buildconf/cplconf/ocn_modelio.nml_0002
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/ocn"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "ocn_0002.log.200824-144539"
+  logfile = "ocn_0002.log.200827-161946"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/Buildconf/cplconf/rof_modelio.nml_0001
+++ b/Buildconf/cplconf/rof_modelio.nml_0001
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/rof"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "rof_0001.log.200824-144539"
+  logfile = "rof_0001.log.200827-161946"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/Buildconf/cplconf/rof_modelio.nml_0002
+++ b/Buildconf/cplconf/rof_modelio.nml_0002
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/rof"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "rof_0002.log.200824-144539"
+  logfile = "rof_0002.log.200827-161946"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/Buildconf/cplconf/wav_modelio.nml_0001
+++ b/Buildconf/cplconf/wav_modelio.nml_0001
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/wav"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "wav_0001.log.200824-144539"
+  logfile = "wav_0001.log.200827-161946"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/Buildconf/cplconf/wav_modelio.nml_0002
+++ b/Buildconf/cplconf/wav_modelio.nml_0002
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/wav"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "wav_0002.log.200824-144539"
+  logfile = "wav_0002.log.200827-161946"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/CaseDocs/atm_modelio.nml_0001
+++ b/CaseDocs/atm_modelio.nml_0001
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/atm"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "atm_0001.log.200824-144539"
+  logfile = "atm_0001.log.200827-161946"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/CaseDocs/atm_modelio.nml_0002
+++ b/CaseDocs/atm_modelio.nml_0002
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/atm"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "atm_0002.log.200824-144539"
+  logfile = "atm_0002.log.200827-161946"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/CaseDocs/cpl_modelio.nml_0001
+++ b/CaseDocs/cpl_modelio.nml_0001
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/cpl"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "cpl_0001.log.200824-144539"
+  logfile = "cpl_0001.log.200827-161946"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/CaseDocs/cpl_modelio.nml_0002
+++ b/CaseDocs/cpl_modelio.nml_0002
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/cpl"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "cpl_0002.log.200824-144539"
+  logfile = "cpl_0002.log.200827-161946"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/CaseDocs/esp_modelio.nml_0001
+++ b/CaseDocs/esp_modelio.nml_0001
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/esp"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "esp_0001.log.200824-144539"
+  logfile = "esp_0001.log.200827-161946"
 /
 &pio_inparm
   pio_netcdf_format = ""

--- a/CaseDocs/esp_modelio.nml_0002
+++ b/CaseDocs/esp_modelio.nml_0002
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/esp"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "esp_0002.log.200824-144539"
+  logfile = "esp_0002.log.200827-161946"
 /
 &pio_inparm
   pio_netcdf_format = ""

--- a/CaseDocs/glc_modelio.nml_0001
+++ b/CaseDocs/glc_modelio.nml_0001
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/glc"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "glc_0001.log.200824-144539"
+  logfile = "glc_0001.log.200827-161946"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/CaseDocs/glc_modelio.nml_0002
+++ b/CaseDocs/glc_modelio.nml_0002
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/glc"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "glc_0002.log.200824-144539"
+  logfile = "glc_0002.log.200827-161946"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/CaseDocs/ice_modelio.nml_0001
+++ b/CaseDocs/ice_modelio.nml_0001
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/ice"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "ice_0001.log.200824-144539"
+  logfile = "ice_0001.log.200827-161946"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/CaseDocs/ice_modelio.nml_0002
+++ b/CaseDocs/ice_modelio.nml_0002
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/ice"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "ice_0002.log.200824-144539"
+  logfile = "ice_0002.log.200827-161946"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/CaseDocs/lnd_modelio.nml_0001
+++ b/CaseDocs/lnd_modelio.nml_0001
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/lnd"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "lnd_0001.log.200824-144539"
+  logfile = "lnd_0001.log.200827-161946"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/CaseDocs/lnd_modelio.nml_0002
+++ b/CaseDocs/lnd_modelio.nml_0002
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/lnd"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "lnd_0002.log.200824-144539"
+  logfile = "lnd_0002.log.200827-161946"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/CaseDocs/ocn_modelio.nml_0001
+++ b/CaseDocs/ocn_modelio.nml_0001
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/ocn"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "ocn_0001.log.200824-144539"
+  logfile = "ocn_0001.log.200827-161946"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/CaseDocs/ocn_modelio.nml_0002
+++ b/CaseDocs/ocn_modelio.nml_0002
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/ocn"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "ocn_0002.log.200824-144539"
+  logfile = "ocn_0002.log.200827-161946"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/CaseDocs/rof_modelio.nml_0001
+++ b/CaseDocs/rof_modelio.nml_0001
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/rof"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "rof_0001.log.200824-144539"
+  logfile = "rof_0001.log.200827-161946"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/CaseDocs/rof_modelio.nml_0002
+++ b/CaseDocs/rof_modelio.nml_0002
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/rof"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "rof_0002.log.200824-144539"
+  logfile = "rof_0002.log.200827-161946"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/CaseDocs/wav_modelio.nml_0001
+++ b/CaseDocs/wav_modelio.nml_0001
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/wav"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "wav_0001.log.200824-144539"
+  logfile = "wav_0001.log.200827-161946"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/CaseDocs/wav_modelio.nml_0002
+++ b/CaseDocs/wav_modelio.nml_0002
@@ -1,7 +1,7 @@
 &modelio
   diri = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/bld/wav"
   diro = "/glade/scratch/raeder/f.e21.FHIST_BGC.f09_025.CAM6assim.011/run"
-  logfile = "wav_0002.log.200824-144539"
+  logfile = "wav_0002.log.200827-161946"
 /
 &pio_inparm
   pio_netcdf_format = "64bit_offset"

--- a/assimilate.csh
+++ b/assimilate.csh
@@ -156,9 +156,9 @@ echo "Brian's suggestions of checks:"
 echo "which mpiexec_mpt"
 which mpiexec_mpt
 echo "mpif90 -show"
-mpif90 -show
-echo "ldd ./filter.exe"
-ldd ${EXEROOT}/filter.exe
+mpif90 -show | sed -e 's# -#\n     -#g'
+echo "ldd ./filter" 
+ldd ${EXEROOT}/filter 
 echo "End of module checking section"
 echo "============================================================="
 

--- a/env_run.xml
+++ b/env_run.xml
@@ -252,7 +252,7 @@
       timing tests.
     </desc>
     </entry>
-    <entry id="JOB_IDS" value="case.run:3702021.chadmin1.ib0.cheyenne.ucar.edu, case.st_archive:3702022.chadmin1.ib0.cheyenne.ucar.edu">
+    <entry id="JOB_IDS" value="case.run:3849146.chadmin1.ib0.cheyenne.ucar.edu">
       <type>char</type>
       <desc>List of job ids for most recent case.submit</desc>
     </entry>
@@ -275,7 +275,7 @@
       <type>integer</type>
       <desc>system workload snapshot frequency (in seconds, if greater than 0; disabled otherwise)</desc>
     </entry>
-    <entry id="DOUT_S_SAVE_INTERIM_RESTART_FILES" value="FALSE">
+    <entry id="DOUT_S_SAVE_INTERIM_RESTART_FILES" value="TRUE">
       <type>logical</type>
       <valid_values>TRUE,FALSE</valid_values>
       <desc>Logical to archive all interim restart files, not just those at eor
@@ -1136,7 +1136,7 @@
       <valid_values/>
       <desc> Number of model run - data assimilation steps to complete </desc>
     </entry>
-    <entry id="DATA_ASSIMILATION_SCRIPT" value="/glade/work/raeder/Exp/f.e21.FHIST_BGC.f09_025.CAM6assim.011/no_assimilate.csh">
+    <entry id="DATA_ASSIMILATION_SCRIPT" value="/glade/work/raeder/Exp/f.e21.FHIST_BGC.f09_025.CAM6assim.011/assimilate.csh">
       <type>char</type>
       <valid_values/>
       <desc>External script to be run after model completion</desc>

--- a/pre_submit.csh
+++ b/pre_submit.csh
@@ -121,7 +121,7 @@ endif
 # it's convenient to make st_archive run automatically
 # at the end of successful jobs.
 # if ($start[3] == "01") ./xmlchange DOUT_S=FALSE
-if ($end[3] == "01") then
+if ($end[3] == "01" && $end[4] == "00000") then
    ./xmlchange DOUT_S=TRUE
 else
    ./xmlchange DOUT_S=FALSE
@@ -149,6 +149,7 @@ echo "$cycles cycles will be distributed among $resubmissions +1 jobs"
 
 @ job_minutes = ( $cycles_per_job * 7 ) + 10 
 # @ job_minutes = 12 * 60
+if ($job_minutes > 720) set job_minutes = 720
 @ wall_hours  = $job_minutes / 60
 @ wall_mins   = $job_minutes % 60
 set wall_time = `printf %02d:%02d $wall_hours $wall_mins`

--- a/setup_advanced_Rean.original
+++ b/setup_advanced_Rean.original
@@ -1169,12 +1169,12 @@ cd ${caseroot}
 setenv RUNDIR       \`./xmlquery RUNDIR       --value\`
 setenv CONTINUE_RUN \`./xmlquery CONTINUE_RUN --value\`
 
-ls \$RUNDIR/*.i.\${restart_time}.nc
+ls \$RUNDIR/*.r.\${restart_time}.nc
 if (\$status == 0) then
    # The restart set exists in the RUNDIR, regardless of the short term archiver.
    setenv DOUT_S FALSE
 else
-   set hide_loc = \`ls \$RUNDIR:h/Hide*/*_0001.i.\${restart_time}.nc\`
+   set hide_loc = \`ls \$RUNDIR:h/Hide*/*_0001.r.\${restart_time}.nc\`
    if (\$status == 0) then
       # The restart set exists in a Hide directory, regardless of the short term archiver.
       setenv DOUT_S FALSE

--- a/stage_cesm_files
+++ b/stage_cesm_files
@@ -20,12 +20,12 @@ cd /glade/work/raeder/Exp/f.e21.FHIST_BGC.f09_025.CAM6assim.011
 setenv RUNDIR       `./xmlquery RUNDIR       --value`
 setenv CONTINUE_RUN `./xmlquery CONTINUE_RUN --value`
 
-ls $RUNDIR/*.i.${restart_time}.nc
+ls $RUNDIR/*.r.${restart_time}.nc
 if ($status == 0) then
    # The restart set exists in the RUNDIR, regardless of the short term archiver.
    setenv DOUT_S FALSE
 else
-   set hide_loc = `ls $RUNDIR:h/Hide*/*_0001.i.${restart_time}.nc`
+   set hide_loc = `ls $RUNDIR:h/Hide*/*_0001.r.${restart_time}.nc`
    if ($status == 0) then
       # The restart set exists in a Hide directory, regardless of the short term archiver.
       setenv DOUT_S FALSE
@@ -82,6 +82,8 @@ if ( ${CONTINUE_RUN} =~ TRUE ) then
       # The short term archiver is off, which leaves all the restart files
       # in the run directory.  The rpointer files must still be updated to
       # point to the files with the right day/time.
+
+      echo "DOUT_S = FALSE, so restart files should be in RUNDIR"
 
       @ inst=1
       while ($inst <= 80)
@@ -163,7 +165,7 @@ ls *inf*${restart_time}* >& /dev/null
 if ($status != 0) then 
    echo ""
    echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
-   echo "WARNING:  no inflation files were fond for $restart_time"
+   echo "WARNING:  no inflation files were found for $restart_time"
    echo "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
    echo ""
 endif


### PR DESCRIPTION
Now that the debugging mess is done, I will rerun the first cycle
of 2019-09-30 to double check that we are on the right path.
Then I will finish the day and archive it to prepare for 2019-10.

assimilate.csh
>   Fixed name of filter executable in the new environment diagnostics.
>   These diagnostics may be removed soon.
>   **This and future assimilations will use the filter compiled 2020-3-2
>   instead of 2020-7-28 (post cheyenne down time).**

env_run.xml
>   Changed archiving values for this cycle, to check output carefully
>   before it is (re)moved.
>   Restore DATA_ASSIMILATION_SCRIPT to normal value.

pre_submit.csh
>   More robust test for setting DOUT_S, to prevent wrong setting
>   when ending a job in the first day of a month, for debugging.

stage_cesm_files
setup_advanced_Rean.original
>   Replace tests for the existence of .i. with .r. because
>   .i. files can be left in RUNDIR, even when restarts are gone.